### PR TITLE
Add dsh-cost-meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 ## Context, Memory & Observability
 
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant) - Offline, deterministic replacement for DSH's basic compaction seam, with recall tools for the append-only session log.
+- [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) - Per-session and daily API cost, budget, and official-balance tracking for the DSH Web UI, with a history dashboard and one-click official price sync (built against the current dsh web bundle).
 - [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) - Cross-session memory, branch awareness, session search, and self-evolving skills.
 - [Nowledge Mem for DSH](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) - Community memory-plugin bundle built around Nowledge Mem.
 - [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) - Index-free cross-agent session search.


### PR DESCRIPTION
Add **dsh-cost-meter** ([repo](https://github.com/Han-1413141/dsh-cost-meter)) — a session-cost / usage-metering plugin for the DeepSeek Harness Web GUI.

What it does:

- Per-session cost badge in the composer dock or session header, with input / cache / output token breakdown
- Daily cost + official account balance (total / granted / topped-up) in the sidebar
- Budget box with usage %, progress bar and over-budget warnings (today / month / total / custom range)
- Settings dashboard: summary cards, per-session breakdown, day-level history (retention configurable)
- DeepSeek peak/off-peak pricing with effective-time gating and current-tier indicator
- One-click official price sync (parses the official pricing page), manual editing as fallback

Repo is public, non-fork, MIT-licensed, and carries the `dsh-plugin` topic.
Install: `dsh plugin --profile web add github:Han-1413141/dsh-cost-meter`
Screenshots: https://github.com/Han-1413141/dsh-cost-meter#图文演示
Entry added to *Context, Memory & Observability* in README.md, kept alphabetical next to dsh-compaction-instant. Repository provides source-level DSH evidence (bundle patch + dsh manifest, per the inclusion policy).