### PR TITLE
docs: add verification and telemetry plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 - [dsh-trace](https://github.com/vibeinging/dsh-trace) - Export DSH turns, model steps, and tool calls to yiTrace over HTTP.
 - [dsh-sentinel](https://github.com/fuhefei/dsh-sentinel) - Durable file, command, HTTP, process, and webhook watches that wake an agent.
 - [dsh-explain](https://github.com/yuezengwu/dsh-explain) - Local-first learning mode with global learning threads and explainable context.
+- [dsh-telemetry-redactor](https://github.com/030611/dsh-telemetry-redactor) - Redacts supported secret patterns from the exported `session-telemetry/record` copy without changing the canonical session log; audited against DSH commit `47f943859bef60e4160492346772ded9b24f765a` and tested with `dsh-session-telemetry` rc.6.
+- [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) - Writes local JSONL summaries of per-turn tool outcomes and heuristic verification signals without storing prompts, tool arguments, or result text; audited against DSH commit `47f943859bef60e4160492346772ded9b24f765a` and tested with `dsh-session` rc.6.
 
 ## Tools, Integrations & Automation
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -268,6 +268,8 @@ DSH 提供了以层级委派为主的表面与 workflow 组件；子 Agent 接�
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant) - 离线、确定性的 DSH 基础上下文压缩替代实现，并提供 append-only 会话日志的回溯工具。 / Offline deterministic replacement for the DSH basic compaction seam, with append-only-log recall tools.
 - [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) - 受限 CSP 的沙箱可视化卡片。 / Sandboxed visualization cards with a constrained CSP.
 - [dsh-image-to-path](https://github.com/cesaryike/dsh-image-to-path) - 带同源、大小与图片类型检查的工作区图片上传。 / Workspace image upload with same-origin, size, and image-type checks.
+- [dsh-telemetry-redactor](https://github.com/030611/dsh-telemetry-redactor) - 对导出的 `session-telemetry/record` 副本脱敏已支持的秘密模式，不改写权威会话日志；以 DSH 提交 `47f943859bef60e4160492346772ded9b24f765a` 为审计基线，并用 `dsh-session-telemetry` rc.6 实测。 / Redacts supported secret patterns from exported telemetry copies without changing the canonical session log; audited against DSH commit `47f943859bef60e4160492346772ded9b24f765a` and tested with `dsh-session-telemetry` rc.6.
+- [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) - 将每轮工具结果与启发式验证信号摘要写入本地 JSONL，不保存提示词、工具参数或结果正文；以 DSH 提交 `47f943859bef60e4160492346772ded9b24f765a` 为审计基线，并用 `dsh-session` rc.6 实测。 / Writes local JSONL summaries of per-turn tool outcomes and heuristic verification signals without storing prompts, tool arguments, or result text; audited against DSH commit `47f943859bef60e4160492346772ded9b24f765a` and tested with `dsh-session` rc.6.
 
 ## 贡献
 


### PR DESCRIPTION
## Summary

- add `dsh-telemetry-redactor` and `dsh-verification-receipt` to Context, Memory & Observability
- add matching bilingual entries to the verified-update section
- include the exact DSH audit baseline and the rc.6 runtime packages exercised by each release

## Source-level DSH evidence

### `dsh-telemetry-redactor`

- `dsh.plugin.json` identifies an installable profile bundle and binds `cordis.patch.yml`
- `src/index.ts` registers the documented Cordis `session-telemetry/record` waterfall seam
- compatibility metadata audits DSH commit `47f943859bef60e4160492346772ded9b24f765a`; the peer range is `@deepseek-ai/dsh-session-telemetry >=0.1.0-rc.5 <0.2.0`, with rc.6 exercised by release checks

### `dsh-verification-receipt`

- `dsh.plugin.json` and `cordis.patch.yml` provide the package entry and profile-bundle insertion
- `src/index.ts` registers a passive `session/event` observer through the DSH Session service
- compatibility metadata audits the same DSH commit; the peer range is `@deepseek-ai/dsh-session >=0.1.0-rc.5 <0.1.0`, with rc.6 exercised by release checks

## Static security triage

I inspected both manifests, package scripts, lockfiles, runtime entrypoints, development smoke scripts, workflows, licenses, and sensitive-operation surfaces without executing candidate code:

- both repositories are public, non-archived, MIT-licensed, and use the `dsh-plugin` topic
- Telemetry Redactor's runtime does not use filesystem, network, process-spawn, or credential-loading APIs; it transforms only the exported record copy
- Verification Receipt's runtime does not use network or process-spawn APIs; it writes only the configured local JSONL destination and reads `DSH_HOME` to resolve the default path
- both CI workflows have read-only repository permissions
- development packaging scripts use local toolchain/temp-directory operations and are excluded from the published package files
- no unresolved opaque payload, remote-code execution, approval/sandbox bypass, or credential collection was found

This is static triage, not a complete security audit or endorsement.

## Validation

- confirmed both links resolve to public, non-archived repositories
- confirmed each project appears once in each edited README
- ran `git diff --check`

This is a documentation-only change; no code tests were run for this directory submission. AI assistance was used to prepare and validate the submission; all descriptions and evidence above were reviewed against the released repositories and manifests.