### PR TITLE
docs: 登记 dsh-chat-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 - [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) - Restore conversation and workspace state through a persistent change ledger.
 - [dsh-undo](https://github.com/LingLambda/dsh-undo) - Context undo/redo around the last completed agent step.
 - [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) - OpenBiliClaw client integration with recommendation and agent-bridge tools.
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - Import full-fidelity conversation histories from 13 coding agents (Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode / ZCode / Grok Build / OpenClaw / Pi / Hermes / Kimi) as resumable DeepSeek Harness sessions, with reverse export/sync back to Claude Code.
 
 ## Context, Memory & Observability
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-chat-import |
| 仓库 | https://github.com/Nwflower/dsh-chat-import |
| 一句话说明 | 13 种编码 Agent 聊天记录全保真导入为可续聊 DSH 会话，并支持反向导出/同步回 Claude Code |
| 版本 | 0.3.1（npm `dsh-chat-import`） |

## 自检清单

- [x] 仓库已打 `dsh-plugin` topic
- [x] npm 已发布（0.1.0–0.3.1），340 测试 + CI 全绿
- [x] 13 个 `import_*` 工具 + `scan_discover` / `export_claude` / `sync_to_claude` / `list_imported_sessions` / `retract_import` 实测通过

## 改动内容

在 `## Productivity & Agent Workflow` 分类末尾（`dsh-openbiliclaw` 之后）追加：

`- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - Import full-fidelity conversation histories from 13 coding agents (Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode / ZCode / Grok Build / OpenClaw / Pi / Hermes / Kimi) as resumable DeepSeek Harness sessions, with reverse export/sync back to Claude Code.`