### PR TITLE
Add dsh-bash-rtk to Developer Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ flowchart LR
 - [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) - Read-only plugin repository health checks for manifests, patches, and build pitfalls.
 - [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) - Read-only local audit of configuration, plugin provenance, sessions, and network exposure.
 - [dsh-scout](https://github.com/omdsh-dev/dsh-scout) - Read-only environment discovery: software, resources, ports, services, hardware, and workspace.
+- [dsh-bash-rtk](https://github.com/DeepTrial/dsh-bash-rtk) - Routes eligible bash commands through rtk (Rust Token Killer) inside the DSH bash executor to compress tool output and save tokens; safe passthrough when rtk is absent.
 - [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) - Better decoding for UTF-16LE, UTF-8, GBK, and other Bash output encodings.
 - [dsh-tool-approval](https://github.com/ilharp/dsh-tool-approval) - Manual/ask-mode approval for DSH tools.
 


### PR DESCRIPTION
Hi maintainers,

Thank you for curating this list — it has been a helpful resource for discovering DSH plugins.

I would like to propose adding **dsh-bash-rtk**, a DeepSeek Harness plugin I maintain:

- Repo: https://github.com/DeepTrial/dsh-bash-rtk
- What it does: routes eligible bash commands through [rtk](https://github.com/rtk-ai/rtk) (Rust Token Killer) inside the DSH bash executor to compress verbose tool output (git, cargo, pytest, docker, etc.) and reduce token usage. Commands that are too complex to wrap, unknown to rtk, or run when rtk is absent pass through unchanged, so it is safe to enable.
- Compatibility: tested against DeepSeek Harness 0.1.0-rc.x (the plugin depends on the bash-executor and Cordis service contracts). It requires an externally managed `rtk` binary on PATH.
- Verification: the entry links to the public source repository, which is MIT-licensed and publicly accessible.

I placed it alphabetically within the Developer Tooling section, next to the other `dsh-bash-*` entries, and added the `dsh-plugin` GitHub topic to the repository.

Please let me know if you would prefer a different section, wording, or any additional compatibility detail. Thanks for your time and for maintaining the list.