### PR TITLE
Add dsh-continual-evolve to Context, Memory & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 ## Context, Memory & Observability
 
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant) - Offline, deterministic replacement for DSH's basic compaction seam, with recall tools for the append-only session log.
+- [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - Versioned, auditable, rollback-safe harness state (prompt notes, memories, skills, subagent specs) refined from session trajectories; verified against DSH 0.1.0-rc.6.
 - [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) - Per-session and daily API cost, budget, and official-balance tracking for the DSH Web UI, with a history dashboard and one-click official price sync (built against the current dsh web bundle).
 - [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) - Cross-session memory, branch awareness, session search, and self-evolving skills.
 - [Nowledge Mem for DSH](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) - Community memory-plugin bundle built around Nowledge Mem.


### PR DESCRIPTION
Adds [ZK-Andy/dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) — a Continual self-evolution plugin for DeepSeek Harness: versioned, auditable, rollback-safe harness state (prompt notes, memories, skills, subagent specs) refined from session trajectories, with review gates and hot-reloaded skills.

- Declares `dsh.bundle` in package.json → installable via `dsh plugin add dsh-continual-evolve`
- Published on npm (dsh-continual-evolve@0.1.0), MIT license
- Has the `dsh-plugin` GitHub topic