### PR TITLE
Add co-engram — self-evolving team memory (native Cordis plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 
 ## Context, Memory & Observability
 
+- [co-engram](https://github.com/Co-Engram/Co-Engram) - Self-evolving team memory as plain Markdown in git: 38 bare-name memory tools on `ctx.tools` plus a `memory:co-engram` prompt section re-evaluated at every assembly; ships a `dsh.bundle` manifest so `dsh plugin add @co-engram/dsh` activates with zero manual config; process-lock coexistence with its Claude Code (MCP) and OpenClaw hosts; verified against DSH 0.1.0-rc.6.
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant) - Offline, deterministic replacement for DSH's basic compaction seam, with recall tools for the append-only session log.
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - Versioned, auditable, rollback-safe harness state (prompt notes, memories, skills, subagent specs) refined from session trajectories; verified against DSH 0.1.0-rc.6.
 - [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) - Per-session and daily API cost, budget, and official-balance tracking for the DSH Web UI, with a history dashboard and one-click official price sync (built against the current dsh web bundle).


### PR DESCRIPTION
## What

Adds [co-engram](https://github.com/Co-Engram/Co-Engram) to **Context, Memory & Observability**.

## Source-level DSH evidence (per INCLUSION_POLICY)

- npm package **@co-engram/dsh@0.1.0** ships a **`dsh.bundle` manifest** (`dsh` field in package.json + bundled `cordis.patch.yml`) — `dsh plugin --profile <name> add @co-engram/dsh` activates it as a profile layer with zero manual config.
- Source registers on documented Cordis/DSH extension seams:
  - **38 bare-name memory tools** on `ctx.tools` via the official `defineTool` factory (`packages/dsh-plugin/src/index.ts`);
  - a **`memory:co-engram` system-prompt section** (`ctx.systemPrompt.section`, order 120) whose signals (top tags / skill catalog / path overview / pending proposals) are re-evaluated at every prompt assembly.
- Verified against **DSH 0.1.0-rc.6**: e2e round-trip through the real dsh ToolRuntime (`packages/dsh-plugin/test/e2e.spec.ts`) plus a real `dsh --profile headless` boot (`38 tools registered` banner).
- Process-lock coexistence with the project's Claude Code (MCP) and OpenClaw hosts on a shared data repo.

## Entry

```markdown
- [co-engram](https://github.com/Co-Engram/Co-Engram) - Self-evolving team memory as plain Markdown in git: 38 bare-name memory tools on `ctx.tools` plus a `memory:co-engram` prompt section re-evaluated at every assembly; ships a `dsh.bundle` manifest so `dsh plugin add @co-engram/dsh` activates with zero manual config; process-lock coexistence with its Claude Code (MCP) and OpenClaw hosts; verified against DSH 0.1.0-rc.6.
```

Alphabetical placement (first in section), single README.md edit, third-person factual description, links verified. The repo carries the `dsh-plugin` topic.