### PR TITLE
Add dsh-bell-notify plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ flowchart LR
 - [dsh-working-activity](https://github.com/ccch1mneyyy/dsh-working-activity) - Live status line for model activity and tools.
 - [dsh-notification](https://github.com/omdsh-dev/dsh-notification) - Desktop notifications for completed turns with outcome and keyword controls.
 - [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) - Browser and prompt notifications for four session states.
+- [dsh-bell-notify](https://github.com/Laplace-bit/dsh-bell-notify) - Per-lifecycle-event chimes for DSH (startup, tool call, command, approval wait, turn complete, idle) synthesized live with Web Audio — zero audio files — plus a breathing status dot; declarable via a `dsh.bundle` manifest with a Cordis patch.
 - [dsh-deeplink](https://github.com/qyw233/dsh-deeplink) - Open a specified session or workspace directly from a Web UI URL.
 - [dsh-navbar](https://github.com/vlln/dsh-navbar) - Right-edge conversation-node navigation.
 - [dsh-task-status](https://github.com/vlln/dsh-task-status) - Background task progress and live-output status bar.

--- a/README.zh.md
+++ b/README.zh.md
@@ -285,6 +285,7 @@ DSH 提供了以层级委派为主的表面与 workflow 组件；子 Agent 接�
 - [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) - 将每轮工具结果与启发式验证信号摘要写入本地 JSONL，不保存提示词、工具参数或结果正文；以 DSH 提交 `47f943859bef60e4160492346772ded9b24f765a` 为审计基线，并用 `dsh-session` rc.6 实测。 / Writes local JSONL summaries of per-turn tool outcomes and heuristic verification signals without storing prompts, tool arguments, or result text; audited against DSH commit `47f943859bef60e4160492346772ded9b24f765a` and tested with `dsh-session` rc.6.
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - 完整 reverse-skill（85 个 SKILL.md）的 DSH 技能路由包，覆盖逆向工程、授权渗透测试与安全研究。 / An 85-skill DSH router pack for reverse engineering, authorized penetration testing, and security research.
 - [dsh-context](https://github.com/bowenliang123/dsh-context) - 上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。 / Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.
+- [dsh-bell-notify](https://github.com/Laplace-bit/dsh-bell-notify) - 生命周期铃声 + 状态点：为每个环节（启动、工具调用、命令、等待审批、回合完成、空闲）播放专属提示音，Web Audio 实时合成零音频文件，可上传自定义音；经 `dsh.bundle` manifest 与 Cordis patch 声明安装。 / Per-lifecycle-event chimes for DSH, synthesized live with Web Audio (zero audio files), plus a breathing status dot; declarable via a `dsh.bundle` manifest with a Cordis patch.
 
 ## 贡献
 


### PR DESCRIPTION
## Summary

Add [dsh-bell-notify](https://github.com/Laplace-bit/dsh-bell-notify) to **Interfaces & Web UI** in `README.md`, plus a bilingual entry in the "Recently verified additions" section of `README.zh.md`.

`dsh-bell-notify` plays a distinct chime per lifecycle event (startup, tool call, command, approval wait, turn complete, idle), synthesized live with Web Audio — zero audio files — plus a breathing status dot. Each sound can be previewed, replaced with a user-supplied audio file, and reset from a settings panel.

## Source-level DSH verification

Per [INCLUSION_POLICY.md](docs/INCLUSION_POLICY.md), the repo satisfies condition 2: it is a DSH plugin package whose source registers a documented Cordis extension seam — `package.json` declares `dsh.bundle` with `cordis.patch.yml`, and `src/plugin.ts` exports `apply` / `name` / `Config` (host entry), with a browser client under `src/client/`.

## Checklist

- [x] Publicly accessible, working code (build, typecheck, tests in repo)
- [x] Source-level DSH/Cordis extension seam present
- [x] `dsh-plugin` topic set
- [x] Concise, neutral description; both READMEs updated