### PR TITLE
Add dsh-verify — independent browser acceptance testing for agent deliverables

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ flowchart LR
 - [dsh-bash-rtk](https://github.com/DeepTrial/dsh-bash-rtk) - Routes eligible bash commands through rtk (Rust Token Killer) inside the DSH bash executor to compress tool output and save tokens; safe passthrough when rtk is absent.
 - [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) - Better decoding for UTF-16LE, UTF-8, GBK, and other Bash output encodings.
 - [dsh-tool-approval](https://github.com/ilharp/dsh-tool-approval) - Manual/ask-mode approval for DSH tools.
+- [dsh-verify](https://github.com/263311487-ux/dsh-verify) - Independent browser acceptance testing for agent deliverables: JSON spec drives real headless Chromium, asserts computed styles and pixel diffs, returns an HTML report and 0/1 exit code; ships npm CLI, GitHub Action, and MCP server.
 
 ## Utilities
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ flowchart LR
 - [dsh-bash-rtk](https://github.com/DeepTrial/dsh-bash-rtk) - Routes eligible bash commands through rtk (Rust Token Killer) inside the DSH bash executor to compress tool output and save tokens; safe passthrough when rtk is absent.
 - [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) - Better decoding for UTF-16LE, UTF-8, GBK, and other Bash output encodings.
 - [dsh-tool-approval](https://github.com/ilharp/dsh-tool-approval) - Manual/ask-mode approval for DSH tools.
-- [dsh-verify](https://github.com/263311487-ux/dsh-verify) - Independent browser acceptance testing for agent deliverables: JSON spec drives real headless Chromium, asserts computed styles and pixel diffs, returns an HTML report and 0/1 exit code; ships npm CLI, GitHub Action, and MCP server.
+- [dsh-verify](https://github.com/263311487-ux/dsh-verify) - Independent browser acceptance testing for agent deliverables (CLI + MCP + DSH plugin). Runs real browsers against the built app and returns PASS/FAIL with screenshot evidence. DSH: `dsh plugin --profile <name> add dsh-verify` registers the dsh_verify tool (npm 0.9.3+).
 
 ## Utilities
 


### PR DESCRIPTION
## dsh-verify — independent browser acceptance testing for agent deliverables

**One-line pitch:** Agents self-test and pass; real browsers tell the truth.

dsh-verify is a tiny, dependency-light acceptance tester for agent-delivered web artifacts. You write (or AI-draft) a JSON checklist of what a human would check in a browser; it launches real headless Chromium, clicks, reads computed styles, pixel-diffs screenshots, and produces an HTML report plus a `0/1` exit code.

**Why it exists:** a 4-agent web team shipped a demo with a dark-mode toggle; their own review said "no issues found" while the toggle literally did nothing in a real browser — the `.dark` CSS rule was missing. Every agent self-test passed because there was nothing to run. The repo ships the buggy and fixed builds side by side as proof.

**Features:**
- JSON spec → real Chromium → HTML report + exit code (drop into any CI)
- Visual regression: `capture_baseline` / `expect_screenshot` (pixel diff with red-highlight diff image)
- AI-drafted checklists: `dsh-verify gen --url <url> --run` (LLM drafts, deterministic browser enforces)
- MCP server (`verify_spec` / `verify_url` / `generate_and_verify`) for Claude Code / Cursor / Copilot
- GitHub Action (`uses: 263311487-ux/dsh-verify/.github/actions/dsh-verify`) — dogfooded on its own CI
- Published on npm (`dsh-verify`), installable via `dsh plugin add dsh-verify` (declares `dsh.bundle`)

16 self-tests green; detection proven end to end (buggy build caught via CLI, MCP, and Action).
