### PR TITLE
Add Open Sea Skin

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ flowchart LR
 - [dsh-paste-input](https://github.com/lhh010/dsh-paste-input) - Clipboard paste, drag-and-drop, and file-picker enhancements.
 - [dsh-input-history](https://github.com/lhh010/dsh-input-history) - Terminal-style input history navigation.
 - [dsh-ui-progress](https://github.com/lhh010/dsh-ui-progress) - Session progress, generation speed, interruption, and todo indicators.
+- [Open Sea Skin](https://github.com/d-dev0101/open-sea-skin) - Local-only WebGPU ocean skin with wave, daylight, glass-opacity, and day-cycle controls. Compatible with DSH Web 0.1.0-rc.6.
 
 ## Developer Tooling
 


### PR DESCRIPTION
Adds a source-verifiable DeepSeek Harness Web appearance plugin.

Verification evidence in the linked repository:
- root `dsh.bundle` and `cordis.patch.yml`
- Host entrypoint serving only packaged local assets
- generated Web client entrypoint using the documented DSH module loader
- explicit DSH Web `0.1.0-rc.6` compatibility
- MIT license and third-party notices
- no analytics, remote code, credentials, model calls, or non-loopback network access
- 12 repository tests plus real browser and isolated DSH installation checks

Release: https://github.com/d-dev0101/open-sea-skin/releases/tag/v1.2.0