### PR TITLE
Add TokenLedger

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant) - Offline, deterministic replacement for DSH's basic compaction seam, with recall tools for the append-only session log.
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - Versioned, auditable, rollback-safe harness state (prompt notes, memories, skills, subagent specs) refined from session trajectories; verified against DSH 0.1.0-rc.6.
 - [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) - Per-session and daily API cost, budget, and official-balance tracking for the DSH Web UI, with a history dashboard and one-click official price sync (built against the current dsh web bundle).
+- [TokenLedger](https://github.com/zh667/TokenLedger) - Local token-usage accounting by relay site, project, and model, with balance and subscription-quota panels; compatible with DSH 0.1.0-rc.6 and later.
 - [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) - Cross-session memory, branch awareness, session search, and self-evolving skills.
 - [Nowledge Mem for DSH](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) - Community memory-plugin bundle built around Nowledge Mem.
 - [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) - Index-free cross-agent session search.


### PR DESCRIPTION
Adds TokenLedger under Context, Memory & Observability.

The repository contains a DSH bundle manifest, documents compatibility with DSH 0.1.0-rc.6 and later, and its test suite passes locally (412 tests).