### PR TITLE
docs: add source-verified dsh-mqtt plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 - [dsh-ssh](https://github.com/UynajGI/dsh-ssh) - Remote execution, SFTP filesystem, ProxyJump, subprocess, and PTY support over SSH.
 - [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) - OpenMAIC classrooms, slides, interactive widgets, and Socratic teaching.
 - [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) - Adaptive deep-research orchestration workflow.
+- [dsh-mqtt](https://github.com/UllrAI/dsh-mqtt) - MQTT protocol driver and agent worker gateway for submitting, steering, observing, and cancelling DSH sessions; tested with DSH `0.1.0-rc.7`.
 - [dsh-openai-codex-auth](https://github.com/yoke233/dsh-openai-codex-auth) - OpenAI Codex OAuth login and usage-card integration.
 - [dsh-plugin-claude-bridge](https://github.com/YYTbit/dsh-plugin-claude-bridge) - Bring Claude Code memory, skills, and configuration into DSH.
 - [dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) - BitFun and DSH ACP integration.

--- a/README.zh.md
+++ b/README.zh.md
@@ -271,6 +271,7 @@ DSH 提供了以层级委派为主的表面与 workflow 组件；子 Agent 接�
 ### 近期通过核验的新增 / Recently verified additions
 
 - [odai-dsh-plugin](https://github.com/orziz/odai/tree/main/dsh/plugin) - 面向整个 DSH profile 的治理与路由 bundle，提供本地作用域语义记忆与可配置的压缩调用；兼容 DSH 0.1.0-rc.6 与 0.1.0-rc.7。 / Profile-wide governance and routing bundle with scoped local semantic memory and configurable compaction calls; compatible with DSH 0.1.0-rc.6 and 0.1.0-rc.7.
+- [dsh-mqtt](https://github.com/UllrAI/dsh-mqtt) - 通过 MQTT 提交、引导、观察和取消 DSH 会话的协议驱动与 Agent Worker 网关；已使用 DSH `0.1.0-rc.7` 测试。 / MQTT protocol driver and agent worker gateway for submitting, steering, observing, and cancelling DSH sessions; tested with DSH `0.1.0-rc.7`.
 - [dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) - 为同一工作区的并行 DSH 会话提供文件认领/释放保护，含过期心跳接管与待处理三路合并区。 / File claim/release protection for parallel DSH sessions in one workspace, with stale-heartbeat takeover and a pending three-way-merge area.
 - [dsh-context-proxy](https://github.com/EvilIrving/dsh-context-proxy) - 基于官方 session-query 与 subprocess 接缝，按需通过 `context_query`、`context_slice`、`context_grep` 读取已持久化会话历史。 / On-demand context tools over persisted session history, using the official session-query and subprocess seams.
 - [dsh-fail-logger](https://github.com/Areium/dsh-fail-logger) - 将原生、Code Mode 与内嵌工具调用失败按错因去重写入本地维护的 Skill 区段；落盘前会脱敏已支持的秘密模式。 / Deduplicates failed tool calls into a locally maintained skill section; supported secret patterns are redacted before persistence.


### PR DESCRIPTION
## Summary

Add [UllrAI/dsh-mqtt](https://github.com/UllrAI/dsh-mqtt) to the English tools/integrations list and the Chinese recently verified list.

## Source-level DSH evidence

- `package.json` declares `dsh.bundle.patch`
- the referenced `cordis.patch.yml` is committed
- `src/index.ts` injects the DSH default-model and agents services
- dependencies target DSH `0.1.0-rc.7`
- the package is published as `dsh-mqtt@0.1.0`
- the project verification suite passes 82 tests

The descriptions are factual, bilingual where required, and include the tested DSH compatibility version.