### PR TITLE
docs: add source-verified Sandbase DSH Plugin Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ DSH provides a hierarchy-oriented delegation surface and workflow components; pr
 - [GitHub topic: `dsh-plugin`](https://github.com/topics/dsh-plugin) - The official recommended GitHub topic for DSH plugin repositories.
 - [Plugin registry](https://github.com/vlln/plugin-registry) - A lightweight repository-plugin console and `make-dsh-plugin` development guide.
 - [Plugin workshop](https://github.com/omdsh-dev/dsh-hub-workshop) - Community plugin-marketplace and registry workshop.
+- [Sandbase DSH Plugin Store](https://github.com/sandbaseai/dsh-plugin-store) - Native Settings marketplace for catalog search, tag filtering, plugin installation, and installed-package inventory; source preview developed against DSH `0.1.0-rc.5`.
 
 ### Curation policy
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -242,6 +242,7 @@ DSH 提供了以层级委派为主的表面与 workflow 组件；子 Agent 接�
 - [GitHub `dsh-plugin` topic](https://github.com/topics/dsh-plugin) - 官方建议用于 DSH 插件发现的 topic；**仅用于发现，不构成收录证据**。
 - [插件注册表](https://github.com/vlln/plugin-registry) - Repository-plugin 控制台和 `make-dsh-plugin` 开发指导。
 - [插件工作坊](https://github.com/omdsh-dev/dsh-hub-workshop) - 社区插件市场和注册表实践。
+- [Sandbase DSH Plugin Store](https://github.com/sandbaseai/dsh-plugin-store) - DSH 设置页原生插件市场，提供目录搜索、标签筛选、插件安装与已安装包清单；源码预览基于 DSH `0.1.0-rc.5` 开发。
 
 ## 收录保证
 


### PR DESCRIPTION
## Summary

Add Sandbase DSH Plugin Store to the bilingual Install and Discover Plugins section, with the current compatibility boundary stated explicitly.

## Source-level DSH evidence

Reviewed target commit: 9c4fde0c8086696cf71a9a77f071025a4d013bca

- package.json declares dsh.bundle.patch at cordis.patch.yml and a Web client manifest.
- src/index.ts exports apply(ctx), injects tools, web, and webServer, registers three DSH tools plus same-origin catalog and install routes.
- src/client/index.tsx injects the native settings.section slot and remote.pluginInventory service.
- README and SECURITY.md state the current compatibility target: DSH 0.1.0-rc.5 source preview.

## Static security triage

- No install, preinstall, postinstall, or prepare lifecycle scripts.
- No credential-store access, secret collection, file writes, or opaque payloads found in the source tree.
- Network access is limited to the configurable catalog endpoint and browser source links.
- The install route validates owner/repository syntax, requires the repository to have appeared in the loaded catalog, caps request bodies at 16 KiB, and invokes the current DSH CLI with a fixed plugin-add argument shape.
- The installer can download and execute third-party plugin code with DSH process permissions; the project documents this trust boundary and recommends source review, private allowlists, isolation, controlled egress, and audit for enterprise use.

This is static triage, not a complete security audit or compatibility guarantee.

## PR scope

- README.md: one English entry.
- README.zh.md: one matching Simplified Chinese entry.
- Canonical repository link returns HTTP 200.
- git diff --check passes.