### PR TITLE
Add dsh-mobile to the curated list

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ flowchart LR
 
 ## Interfaces & Web UI
 
+- [dsh-mobile](https://github.com/saya-ch/dsh-mobile) - Paired HTTPS access to the native DSH Web profile from Android or mobile browsers, with a dedicated mobile layout, separate LAN and optional Funnel/cpolar routes, and compatibility verified against DSH 0.1.1-rc.2.
 - [dsh-reasoning-effort](https://github.com/HanaAyane/dsh-reasoning-effort) - Codex-style session model and reasoning-effort selector that follows adapter-advertised levels, with read-only guidance for custom-provider declarations.
 - [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) - Login gateway for remote, multi-user DSH Web access, with HTTPS, quotas, sandbox restrictions, and audit logs.
 - [dsh-ux-simple](https://github.com/KhalilYamber/dsh-ux-simple) - A two-mode Web UI that provides plain-language tool-call cards while preserving the native view.

--- a/README.zh.md
+++ b/README.zh.md
@@ -270,6 +270,7 @@ DSH 提供了以层级委派为主的表面与 workflow 组件；子 Agent 接�
 
 ### 近期通过核验的新增 / Recently verified additions
 
+- [dsh-mobile](https://github.com/saya-ch/dsh-mobile) - 为 Android App 和手机浏览器提供经过配对认证的 DSH HTTPS 访问，包含独立移动布局、相互分离的局域网与可选 Funnel/cpolar 远程通道；已验证兼容 DSH 0.1.1-rc.2。 / Paired HTTPS access to the native DSH Web profile from Android or mobile browsers, with a dedicated mobile layout, separate LAN and optional Funnel/cpolar routes; verified with DSH 0.1.1-rc.2.
 - [dsh-llm-verifier](https://github.com/Web0926/dsh-llm-verifier) - 经审批的 3/5 路编码 Agent 优选编排：隔离 Git worktree、宿主验证命令、LLM 验证器与独立赢家应用步骤，并包含凭据和进程输出防护。 / Approval-gated best-of-3/5 coding-agent orchestration with isolated Git worktrees, host validation commands, an LLM verifier, and a separate winner-apply step with credential and process-output safeguards.
 - [DeepSeek Harness Brain](https://github.com/AgriciDaniel/deepseek-harness-brain) - 带来源引用的学习与开发资源，含白话指南、Obsidian 知识库、辅助 Skill 与可移植性指引；基于固定 DSH 上游提交审阅。 / Source-cited learning and development resource with a plain-English guide, Obsidian knowledge base, assistant skill, and portability guidance; reviewed against a pinned upstream DSH commit.
 - [dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) - 为 DeepSeek Harness Web UI 提供流畅流式渲染和丝滑滚动；已使用 DSH 0.1.0-rc.6 测试。 / Fluid streaming rendering and smooth scrolling for the DeepSeek Harness Web UI; tested with DSH 0.1.0-rc.6.


### PR DESCRIPTION
## Summary  - add `dsh-mobile` to **Interfaces & Web UI** - add the required bilingual entry to **Recently verified additions**  Official DSH ecosystem post: https://github.com/deepseek-ai/deepseek-harness/discussions/4289

## Source-level DSH integration evidence  - [`package.json`](https://github.com/saya-ch/dsh-mobile/blob/f41818141d236c6bac666b814d41592b5a6cce5c/package.json) declares the DSH bundle patch and Web client face. - [`cordis.patch.yml`](https://github.com/saya-ch/dsh-mobile/blob/f41818141d236c6bac666b814d41592b5a6cce5c/cordis.patch.yml) mounts the Host plugin through the stock Web profile and injects `webServer`. - [`src/plugin.ts`](https://github.com/saya-ch/dsh-mobile/blob/f41818141d236c6bac666b814d41592b5a6cce5c/src/plugin.ts) exports the Cordis `apply()` lifecycle and registers the gateway with the DSH Web server. - [`src/client.ts`](https://github.com/saya-ch/dsh-mobile/blob/f41818141d236c6bac666b814d41592b5a6cce5c/src/client.ts) and [`src/mobile-layout.ts`](https://github.com/saya-ch/dsh-mobile/blob/f41818141d236c6bac666b814d41592b5a6cce5c/src/mobile-layout.ts) contribute the DSH client surface and dedicated mobile root layout.  Version `0.2.0` documents compatibility with the DSH `0.1.1` line and has been verified against `0.1.1-rc.2`.  ## Security-sensitive behavior disclosed for review  The plugin opens a paired HTTPS mobile gateway, stores local CA/device state under `$DSH_HOME/mobile-access/`, and can optionally start a bundled Tailscale Funnel helper or download a pinned cpolar component only after an explicit user action. Pairing, remote-provider behavior, trusted-device scope, cleanup, and checksums are documented in [`SECURITY.md`](https://github.com/saya-ch/dsh-mobile/blob/f41818141d236c6bac666b814d41592b5a6cce5c/SECURITY.md), the README, and release assets.