### PR TITLE
Add dsh-tmux-cc to Interfaces & Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ flowchart LR
 - [dsh-tui](https://github.com/orriduck/dsh-tui) - Small session-aware terminal UI.
 - [dsh-cc-tui](https://github.com/ccch1mneyyy/dsh-cc-tui) - Claude Code-style full-screen terminal interface.
 - [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) - Terminal UI for DSH.
+- [dsh-tmux-cc](https://github.com/adrianleb/dsh-tmux-cc) - Persistent tmux control-mode cockpit for DSH Web that mirrors native panes in a dock.
 - [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) - Use DSH through grok-build's TUI.
 - [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) - Reduced chat view that emphasizes final outputs.
 - [dsh-working-activity](https://github.com/ccch1mneyyy/dsh-working-activity) - Live status line for model activity and tools.

--- a/README.zh.md
+++ b/README.zh.md
@@ -270,6 +270,7 @@ DSH 提供了以层级委派为主的表面与 workflow 组件；子 Agent 接�
 
 ### 近期通过核验的新增 / Recently verified additions
 
+- [dsh-tmux-cc](https://github.com/adrianleb/dsh-tmux-cc) - 为 DSH Web 提供持久的 tmux 控制模式驾驶舱，在停靠栏中镜像原生窗格。 / Persistent tmux control-mode cockpit for DSH Web that mirrors native panes in a dock.
 - [dsh-mobile](https://github.com/saya-ch/dsh-mobile) - 为 Android App 和手机浏览器提供经过配对认证的 DSH HTTPS 访问，包含独立移动布局、相互分离的局域网与可选 Funnel/cpolar 远程通道；已验证兼容 DSH 0.1.1-rc.2。 / Paired HTTPS access to the native DSH Web profile from Android or mobile browsers, with a dedicated mobile layout, separate LAN and optional Funnel/cpolar routes; verified with DSH 0.1.1-rc.2.
 - [dsh-llm-verifier](https://github.com/Web0926/dsh-llm-verifier) - 经审批的 3/5 路编码 Agent 优选编排：隔离 Git worktree、宿主验证命令、LLM 验证器与独立赢家应用步骤，并包含凭据和进程输出防护。 / Approval-gated best-of-3/5 coding-agent orchestration with isolated Git worktrees, host validation commands, an LLM verifier, and a separate winner-apply step with credential and process-output safeguards.
 - [DeepSeek Harness Brain](https://github.com/AgriciDaniel/deepseek-harness-brain) - 带来源引用的学习与开发资源，含白话指南、Obsidian 知识库、辅助 Skill 与可移植性指引；基于固定 DSH 上游提交审阅。 / Source-cited learning and development resource with a plain-English guide, Obsidian knowledge base, assistant skill, and portability guidance; reviewed against a pinned upstream DSH commit.


### PR DESCRIPTION
Add [dsh-tmux-cc](https://github.com/adrianleb/dsh-tmux-cc) under Interfaces & Web UI.

It is a real DSH Web plugin (`dsh.bundle` + `cordis.patch.yml`) that attaches to an existing tmux session with `tmux -C` and mirrors native panes in a persistent dock.

Install: `dsh plugin --profile web add github:adrianleb/dsh-tmux-cc`