### PR TITLE
docs: add DeepSeek Harness Handbook to ecosystem indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ These are community indexes rather than individual plugins; use them as secondar
 - [DSHPlugin.app](https://dshplugin.app/) - Independent DSH plugin directory with source-backed capability summaries, install information, repository activity, and security signals.
 - [oh-my-dsh](https://github.com/wangshunnn/oh-my-dsh) - DSH plugin collection.
 - [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) - Large DSH extension ecosystem catalog.
+- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - Agent-first, source-backed guides and a capability-indexed resource map; use its version pins and verification notes as a secondary research surface, not an installation or security endorsement.
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -243,6 +243,7 @@ DSH 提供了以层级委派为主的表面与 workflow 组件；子 Agent 接�
 - [GitHub `dsh-plugin` topic](https://github.com/topics/dsh-plugin) - 官方建议用于 DSH 插件发现的 topic；**仅用于发现，不构成收录证据**。
 - [插件注册表](https://github.com/vlln/plugin-registry) - Repository-plugin 控制台和 `make-dsh-plugin` 开发指导。
 - [插件工作坊](https://github.com/omdsh-dev/dsh-hub-workshop) - 社区插件市场和注册表实践。
+- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - 面向 Agent 的来源可追溯指南与按能力索引的资源地图；请将版本固定和验证说明作为辅助研究入口，不要视为安装或安全背书。
 
 ## 收录保证
 


### PR DESCRIPTION
## Summary
- add the DeepSeek Harness Handbook to the non-plugin ecosystem index
- describe its Agent-first, source-backed guide and capability map
- keep the entry explicitly secondary discovery, not an install or security endorsement

## Evidence
- Handbook: https://github.com/sandbaseai/deepseek-harness-handbook
- Capability map: https://sandbaseai.github.io/deepseek-harness-handbook/awesome-deepseek-harness-resources.html
- Current release: v0.5.429
- The handbook runs `npm run check` and `npm run check:resources`; its index is pinned to the upstream Awesome snapshot.

This belongs under Ecosystem Indexes rather than a plugin category per the inclusion policy.