### PR TITLE
Add dsh-super-pm to Developer Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ flowchart LR
 - [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) - Read-only plugin repository health checks for manifests, patches, and build pitfalls.
 - [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) - Read-only local audit of configuration, plugin provenance, sessions, and network exposure.
 - [dsh-scout](https://github.com/omdsh-dev/dsh-scout) - Read-only environment discovery: software, resources, ports, services, hardware, and workspace.
+- [dsh-super-pm](https://github.com/Lohaslee/dsh-super-pm) - Product-thinking companion for DeepSeek Harness: clarifies negative boundaries first, separates facts from assumptions, routes through seven product lenses, and persists confirmed decisions to project memory.
 - [dsh-bash-rtk](https://github.com/DeepTrial/dsh-bash-rtk) - Routes eligible bash commands through rtk (Rust Token Killer) inside the DSH bash executor to compress tool output and save tokens; safe passthrough when rtk is absent.
 - [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) - Better decoding for UTF-16LE, UTF-8, GBK, and other Bash output encodings.
 - [dsh-tool-approval](https://github.com/ilharp/dsh-tool-approval) - Manual/ask-mode approval for DSH tools.

--- a/README.zh.md
+++ b/README.zh.md
@@ -307,6 +307,7 @@ DSH 提供了以层级委派为主的表面与 workflow 组件；子 Agent 接�
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - 完整 reverse-skill（85 个 SKILL.md）的 DSH 技能路由包，覆盖逆向工程、授权渗透测试与安全研究。 / An 85-skill DSH router pack for reverse engineering, authorized penetration testing, and security research.
 - [dsh-context](https://github.com/bowenliang123/dsh-context) - 上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。 / Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.
 - [dsh-bell-notify](https://github.com/Laplace-bit/dsh-bell-notify) - 生命周期铃声 + 状态点：为每个环节（启动、工具调用、命令、等待审批、回合完成、空闲）播放专属提示音，Web Audio 实时合成零音频文件，可上传自定义音；经 `dsh.bundle` manifest 与 Cordis patch 声明安装。 / Per-lifecycle-event chimes for DSH, synthesized live with Web Audio (zero audio files), plus a breathing status dot; declarable via a `dsh.bundle` manifest with a Cordis patch.
+- [dsh-super-pm](https://github.com/Lohaslee/dsh-super-pm) - DeepSeek Harness 的产品思考助手：先明确负向边界，拆开事实与假设，经七套产品视角讨论取舍，并将确认的决策沉淀到项目记忆中。 / Product-thinking companion for DeepSeek Harness: clarifies negative boundaries first, separates facts from assumptions, routes through seven product lenses, and persists confirmed decisions to project memory.
 
 ## 贡献
 


### PR DESCRIPTION
## Summary

Add [dsh-super-pm](https://github.com/Lohaslee/dsh-super-pm) to the Developer Tooling section.

**What it does:** Product-thinking companion for DeepSeek Harness: clarifies negative boundaries first, separates facts from assumptions, routes through seven product lenses, and persists confirmed decisions to project memory.

**Compatibility:** DSH plugin with a `dsh.bundle.patch` manifest and Cordis patch; installable with `dsh plugin --profile <name> add dsh-super-pm`.

**Verification:**
- `dsh.bundle.patch` declared in `package.json`
- `cordis.patch.yml` present
- npm package `dsh-super-pm` published
- `dsh-plugin` GitHub topic set
- 14 commits, repo created 2026-09-01, actively maintained