### PR TITLE
Add dsh-continue (auto-resume for interrupted sessions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 - [dsh-routed-subagent](https://github.com/bpc-oss/dsh-routed-subagent) - Run a one-shot subagent fully mounted on any agent preset from any session, with per-call model/provider override, model pre-check, and external CLI engines (codex / claude / codebuddy) with background jobs, live progress, kill, and continuable sessions.
 - [dsh-fork-to-preset](https://github.com/bpc-oss/dsh-fork-to-preset) - Fork any session into a different agent preset from the conversation header: a preset picker creates a new child session mounted on the chosen preset, inheriting the source session's completed turns.
 
+- [dsh-continue](https://github.com/weibaohui/dsh-continue) - Auto-resume for interrupted DSH agent sessions: an ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) into backoff retry, model switch, resume after compaction, or stop-loss notification, with a visual rule editor and activity log; installs via the `dsh.bundle` manifest (npm `@weibaohui/dsh-continue`).
+
 ## Context, Memory & Observability
 
 - [dsh-context-proxy](https://github.com/EvilIrving/dsh-context-proxy) - On-demand `context_query`, `context_slice`, and `context_grep` tools over persisted session history, using the official session-query and subprocess seams.


### PR DESCRIPTION
Adds **dsh-continue** to **Productivity & Agent Workflow**.

Auto-resume for interrupted DSH agent sessions: an ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) into automatic backoff retry, model switch, resume after context compaction, or a stop-loss notification, with a visual rule editor and a full activity log.

Per the inclusion policy: the repo declares a real `dsh.bundle` manifest with `cordis.patch.yml` in `package.json`, is published to npm as `@weibaohui/dsh-continue` (v0.3.0, MIT), carries the `dsh-plugin` topic, and is actively maintained (last push 2026-09). I did not state a pinned DSH version since the plugin does not hard-pin one; it installs through the standard `dsh plugin add` path.

Demo: https://github.com/weibaohui/dsh-continue/blob/main/docs/demo.gif

> README.zh.md looks like a maintainer-curated condensed index, so I left it untouched for your verification flow — happy to add bilingual lines if you prefer.
