### PR TITLE
Add hermes-loop (session retrospective to reusable skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 - [dsh-telemetry-redactor](https://github.com/030611/dsh-telemetry-redactor) - Redacts supported secret patterns from the exported `session-telemetry/record` copy without changing the canonical session log; audited against DSH commit `47f943859bef60e4160492346772ded9b24f765a` and tested with `dsh-session-telemetry` rc.6.
 - [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) - Writes local JSONL summaries of per-turn tool outcomes and heuristic verification signals without storing prompts, tool arguments, or result text; audited against DSH commit `47f943859bef60e4160492346772ded9b24f765a` and tested with `dsh-session` rc.6.
 
+- [hermes-loop](https://github.com/weibaohui/hermes-loop) - Automatic post-conversation retrospective for DSH that distills useful experience into reusable skills for the skill library, with signal-accelerated triggers, an approval mode, and skill-library governance (archive/restore); installs via the `dsh.bundle` manifest (npm `@weibaohui/hermes-loop`).
+
 ## Tools, Integrations & Automation
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 


### PR DESCRIPTION
Adds **hermes-loop** to **Context, Memory & Observability**.

Automatic post-conversation retrospective: after a DSH conversation wraps up, it distills useful experience into reusable skills stored in the skill library for the model to call, with signal-accelerated triggers, manual runs, an approval mode, and skill-library governance (archive/restore, never deletes directly).

Per the inclusion policy: real `dsh.bundle` manifest with `cordis.patch.yml` in `package.json`, published to npm as `@weibaohui/hermes-loop` (v0.1.4, MIT), carries the `dsh-plugin` topic, actively maintained.

Demo: https://github.com/weibaohui/hermes-loop/blob/main/docs/demo.gif

> README.zh.md left untouched for your verification flow — happy to add bilingual lines if you prefer.
