### PR TITLE
Add dsh-xiuxian (Xianxia desktop pets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ flowchart LR
 
 - [dsh-minigames](https://github.com/lhh010/dsh-minigames) - An offline DSH Web side panel with 18 mini-games, including Dino, Tetris, Tanks, Gomoku, and Minesweeper.
 
+- [dsh-xiuxian](https://github.com/weibaohui/dsh-xiuxian) - Xianxia desktop pets for DSH tied to live agent sessions: MC pixel-style companions appear as subagents spawn (up to 3 on screen), with storage-bag collection, a right-click artifact menu, a pet gallery, and Codex pet-format export; installs via the `dsh.bundle` manifest (npm `@weibaohui/dsh-xiuxian`).
+
 ## Launchers & Clients
 
 - [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) - Lightweight Windows autostart launcher with a minimal WebView2 window.


### PR DESCRIPTION
Adds **dsh-xiuxian** to **Games & Play**.

Xianxia desktop pets tied to live DSH agent sessions: MC pixel-style companions appear when subagents spawn (up to 3 on screen), with storage-bag collection, a right-click artifact menu, a pet gallery, and export to the Codex desktop-pet format.

Per the inclusion policy: real `dsh.bundle` manifest with `cordis.patch.yml` in `package.json`, published to npm as `@weibaohui/dsh-xiuxian` (v1.1.1, MIT), carries the `dsh-plugin` topic, actively maintained.

Demo: https://github.com/weibaohui/dsh-xiuxian/blob/main/docs/demo.gif

> README.zh.md left untouched for your verification flow — happy to add bilingual lines if you prefer.
