### PR TITLE
Add dsh-tasks (scheduled tasks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 - [dsh-fork-to-preset](https://github.com/bpc-oss/dsh-fork-to-preset) - Fork any session into a different agent preset from the conversation header: a preset picker creates a new child session mounted on the chosen preset, inheriting the source session's completed turns.
 
 - [dsh-continue](https://github.com/weibaohui/dsh-continue) - Auto-resume for interrupted DSH agent sessions: an ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) into backoff retry, model switch, resume after compaction, or stop-loss notification, with a visual rule editor and activity log; installs via the `dsh.bundle` manifest (npm `@weibaohui/dsh-continue`).
+- [dsh-tasks](https://github.com/weibaohui/dsh-tasks) - Scheduled tasks: run a prompt on cron schedules, each run opens a new agent session to do the work, with workspace binding, manual run, session auto-naming, and a fullscreen task management page; installs via the `dsh.bundle` manifest (npm `@weibaohui/dsh-tasks`).
 
 ## Context, Memory & Observability
 


### PR DESCRIPTION
Adds **dsh-tasks** to **Productivity & Agent Workflow**.

Scheduled tasks: run a prompt on cron schedules, each run opens a new agent session to do the work, with workspace binding, manual run, session auto-naming, and a fullscreen task management page.

Per the inclusion policy: the repo declares a real `dsh.bundle` manifest with `cordis.patch.yml` in `package.json`, is published to npm as `@weibaohui/dsh-tasks` (v0.4.2, MIT), carries the `dsh-plugin` topic, and is actively maintained (last push 2026-09). I did not state a pinned DSH version since the plugin does not hard-pin one; it installs through the standard `dsh plugin add` path.

Demo: https://github.com/weibaohui/dsh-tasks/blob/main/docs/demo.gif

> README.zh.md looks like a maintainer-curated condensed index, so I left it untouched for your verification flow — happy to add bilingual lines if you prefer.
