### PR TITLE
Add skills-management (skill marketplace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ flowchart LR
 - [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) - Better decoding for UTF-16LE, UTF-8, GBK, and other Bash output encodings.
 - [dsh-tool-approval](https://github.com/ilharp/dsh-tool-approval) - Manual/ask-mode approval for DSH tools.
 - [dsh-verify](https://github.com/263311487-ux/dsh-verify) - Independent browser acceptance testing for agent deliverables (CLI + MCP + DSH plugin). Runs real browsers against the built app and returns PASS/FAIL with screenshot evidence. DSH: `dsh plugin --profile <name> add dsh-verify` registers the dsh_verify tool (npm 0.9.3+).
+- [skills-management](https://github.com/weibaohui/skills-management) - Skill marketplace and manager: manage skills from all local coding agents (10+ executors, incl. Claude Code and Codex) in one page and import them into the DSH skill library; built-in market of 6600+ skills, per-skill token-overhead stats, and model visibility control; installs via the `dsh.bundle` manifest (npm `@weibaohui/skills-management`).
 
 ## Utilities
 


### PR DESCRIPTION
Adds **skills-management** to **Developer Tooling**.

Skill marketplace and manager: manage skills from all local coding agents (10+ executors, incl. Claude Code and Codex) in one page and import them into the DSH skill library; built-in market of 6600+ skills, per-skill token-overhead stats, and model visibility control.

Per the inclusion policy: the repo declares a real `dsh.bundle` manifest with `cordis.patch.yml` in `package.json`, is published to npm as `@weibaohui/skills-management` (v0.6.1, MIT), carries the `dsh-plugin` topic, and is actively maintained (last push 2026-09). I did not state a pinned DSH version since the plugin does not hard-pin one; it installs through the standard `dsh plugin add` path.

Demo: https://github.com/weibaohui/skills-management/blob/main/docs/demo.gif

> README.zh.md looks like a maintainer-curated condensed index, so I left it untouched for your verification flow — happy to add bilingual lines if you prefer.
