### PR TITLE
Add user-management (login gate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ flowchart LR
 - [Open Sea Skin](https://github.com/d-dev0101/open-sea-skin) - Local-only WebGPU ocean skin with wave, daylight, glass-opacity, and day-cycle controls. Compatible with DSH Web 0.1.0-rc.6.
 
 - [dsh-settings-ui](https://github.com/weibaohui/dsh-settings-ui) - Settings-window customization for the DSH Web UI: preset or custom window sizes, fullscreen, background transparency, and theme, solid-color, or image backgrounds, with a floating-ball quick access; light and dark themes store separate colors; installs via the `dsh.bundle` manifest (npm `@weibaohui/dsh-settings-ui`).
+- [user-management](https://github.com/weibaohui/user-management) - Login gate for the dsh web UI: unauthenticated visitors get a login/register page and the first registrant becomes admin; includes user and role management plus login and access audit logs; installs via the `dsh.bundle` manifest (npm `@weibaohui/user-management`).
 
 ## Developer Tooling
 


### PR DESCRIPTION
Adds **user-management** to **Interfaces & Web UI**.

Login gate for the dsh web UI: unauthenticated visitors get a login/register page and the first registrant becomes admin; includes user and role management plus login and access audit logs.

Per the inclusion policy: the repo declares a real `dsh.bundle` manifest with `cordis.patch.yml` in `package.json`, is published to npm as `@weibaohui/user-management` (v0.6.1, MIT), carries the `dsh-plugin` topic, and is actively maintained (last push 2026-09). I did not state a pinned DSH version since the plugin does not hard-pin one; it installs through the standard `dsh plugin add` path.

Demo: https://github.com/weibaohui/user-management/blob/main/docs/demo.gif

> README.zh.md looks like a maintainer-curated condensed index, so I left it untouched for your verification flow — happy to add bilingual lines if you prefer.
