### PR TITLE
Add dsh-smart-title

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 
 - [dsh-continue](https://github.com/weibaohui/dsh-continue) - Auto-resume for interrupted DSH agent sessions: an ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) into backoff retry, model switch, resume after compaction, or stop-loss notification, with a visual rule editor and activity log; installs via the `dsh.bundle` manifest (npm `@weibaohui/dsh-continue`).
 - [dsh-tasks](https://github.com/weibaohui/dsh-tasks) - Scheduled tasks: run a prompt on cron schedules, each run opens a new agent session to do the work, with workspace binding, manual run, session auto-naming, and a fullscreen task management page; installs via the `dsh.bundle` manifest (npm `@weibaohui/dsh-tasks`).
+- [dsh-smart-title](https://github.com/weibaohui/dsh-smart-title) - Smart session titles for DSH: after each conversation turn an independent auxiliary LLM call summarizes the full user+assistant transcript into a title that follows the session's real topic instead of echoing the first message; the first message is titled instantly, failed built-in titles auto-retry on later turns, manual renames are never overwritten, and subagent/fork sessions are skipped; installs via the `dsh.bundle` manifest (npm `@weibaohui/dsh-smart-title`).
 
 ## Context, Memory & Observability
 


### PR DESCRIPTION
Adds **dsh-smart-title** to **Productivity & Agent Workflow**.

Smart session titles for DSH: after each conversation turn an independent auxiliary LLM call (`ctx.llm`, purpose: `session-title`, not consuming the main conversation context) summarizes the full user-message + assistant-answer transcript into a title that follows the session's real topic instead of echoing the first message. The first message is titled instantly; failed built-in titles auto-retry on later turns; manual renames are never overwritten; subagent/fork sessions are skipped; a cheaper model can be routed separately for title calls, with optional startup backfill of existing fallback titles.

Per the inclusion policy: the repo declares a real `dsh.bundle` manifest (`dsh.bundle.patch = ./cordis.patch.yml` in `package.json`), is published to npm as `@weibaohui/dsh-smart-title` (v0.1.0, MIT), carries the `dsh-plugin` topic (also `dsh`, `deepseek-harness`), and is actively maintained (last push 2026-09). I did not state a pinned DSH version since the plugin does not hard-pin one; it installs through the standard `dsh plugin add @weibaohui/dsh-smart-title` path.

> README.zh.md looks like a maintainer-curated condensed index, so I left it untouched for your verification flow — happy to add bilingual lines if you prefer.
