### PR TITLE
docs: add DSPlugin.app to Ecosystem Indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ These are community indexes rather than individual plugins; use them as secondar
 - [awesome-deepseek-harness](https://github.com/Dominic789654/awesome-deepseek-harness) - DSH plugins, skills, MCP servers, orchestrators, and UIs.
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) - Bilingual directory with daily compatibility CI and a scaffold.
 - [DSHPlugin.app](https://dshplugin.app/) - Independent DSH plugin directory with source-backed capability summaries, install information, repository activity, and security signals.
+- [DSPlugin.app](https://dsplugin.app/) - Unofficial community DSH plugin directory/registry (Manifest/`dsh.bundle`).
 - [oh-my-dsh](https://github.com/wangshunnn/oh-my-dsh) - DSH plugin collection.
 - [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) - Large DSH extension ecosystem catalog.
 


### PR DESCRIPTION
## Summary
- Add [DSPlugin.app](https://dsplugin.app/) under **Ecosystem Indexes** as an unofficial community DSH plugin directory/registry (Manifest / `dsh.bundle`).
- Leaves the existing [DSHPlugin.app](https://dshplugin.app/) row untouched.

## Test plan
- [ ] Confirm the new bullet renders under Ecosystem Indexes
- [ ] Confirm DSHPlugin.app entry is unchanged
- [ ] Confirm link resolves