### PR TITLE
Add Busabase DSH plugin to Context, Memory & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ The `dsh-plugin` topic, a `dsh-` repository name, or a README claim alone is **n
 
 ## Context, Memory & Observability
 
+- [Busabase](https://github.com/busabase/busabase-dsh-plugin) - Searchable knowledge and structured records with human-reviewed proposed writes, MCP tools, and Web UI cards; `@busabase/dsh-plugin` 0.1.6 declares DSH 0.1.1-rc.2 peer dependencies.
 - [dsh-context-proxy](https://github.com/EvilIrving/dsh-context-proxy) - On-demand `context_query`, `context_slice`, and `context_grep` tools over persisted session history, using the official session-query and subprocess seams.
 - [co-engram](https://github.com/Co-Engram/Co-Engram) - Self-evolving team memory as plain Markdown in git: 38 bare-name memory tools on `ctx.tools` plus a `memory:co-engram` prompt section re-evaluated at every assembly; ships a `dsh.bundle` manifest so `dsh plugin add @co-engram/dsh` activates with zero manual config; process-lock coexistence with its Claude Code (MCP) and OpenClaw hosts; verified against DSH 0.1.0-rc.6.
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant) - Offline, deterministic replacement for DSH's basic compaction seam, with recall tools for the append-only session log.

--- a/README.zh.md
+++ b/README.zh.md
@@ -271,6 +271,8 @@ DSH 提供了以层级委派为主的表面与 workflow 组件；子 Agent 接�
 
 ### 近期通过核验的新增 / Recently verified additions
 
+- [Busabase](https://github.com/busabase/busabase-dsh-plugin) - 可检索的知识与结构化记录，支持人工审核拟议写入、MCP 工具及 Web UI 卡片；`@busabase/dsh-plugin` 0.1.6 声明 DSH 0.1.1-rc.2 peer 依赖。 / Searchable knowledge and structured records with human-reviewed proposed writes, MCP tools, and Web UI cards; `@busabase/dsh-plugin` 0.1.6 declares DSH 0.1.1-rc.2 peer dependencies.
+
 - [dsh-crew](https://github.com/ZSeven-W/dsh-crew) - 从 Claude Code 或 Codex 调度 DSH Worker，提供宿主内会话、实时进度、工作区锁与递归防护；外部 CLI Worker 需显式选择，且会使用其文档所述的始终批准模式。 / Dispatch DSH workers from Claude Code or Codex with in-host sessions, live progress, workspace locks, and recursion guards; external CLI workers are an explicit opt-in and use their documented always-approve modes.
 
 - [dsh-schematic](https://github.com/Mason-1011/dsh-schematic) - 实时插件拓扑与活动查看器，带受保护的组合工作台：编辑先预览、校验、备份，且可回滚；已使用 DSH 0.1.0-rc.8 测试。 / Live plugin-topology and activity viewer with a guarded composition workbench: edits are previewed, validated, backed up, and reversible; tested with DSH 0.1.0-rc.8.


### PR DESCRIPTION
## Summary

Add Busabase to Context, Memory & Observability, with a matching bilingual addition in the Chinese README's existing additions section. No existing entries are reordered.

Disclosure: this is a Busabase-affiliated submission, prepared with AI assistance, not an independent endorsement.

## Source-level evidence

Inspected source revision: [`b065c5a5b19069991516d590b1b3bc3802bef31a`](https://github.com/busabase/busabase-dsh-plugin/tree/b065c5a5b19069991516d590b1b3bc3802bef31a).

- [package.json](https://github.com/busabase/busabase-dsh-plugin/blob/b065c5a5b19069991516d590b1b3bc3802bef31a/package.json): MIT, version 0.1.6, `dsh.bundle.patch`, web client declaration, Node >=24.18.0, DSH peers at 0.1.1-rc.2.
- [cordis.patch.yml](https://github.com/busabase/busabase-dsh-plugin/blob/b065c5a5b19069991516d590b1b3bc3802bef31a/cordis.patch.yml): activates the package as a Cordis plugin.
- [src/index.ts](https://github.com/busabase/busabase-dsh-plugin/blob/b065c5a5b19069991516d590b1b3bc3802bef31a/src/index.ts): registers a skill provider, system-prompt section and start tool; connects the official DSH MCP client locally.
- [src/client.tsx](https://github.com/busabase/busabase-dsh-plugin/blob/b065c5a5b19069991516d590b1b3bc3802bef31a/src/client.tsx): DSH slots/layout/sessions integration for cards and Inspector.
- These map to the official [capability seams](https://github.com/deepseek-ai/deepseek-harness/blob/c291e7961a515f6d7af9304e7fd1d257929aef26/docs/capability-seams.md), including `ctx.tools`, `ctx.systemPrompt` and `ctx.skills`.

The listing reports declared peer compatibility, not a new runtime verification or compatibility with newer DSH releases.

## Static review scope and boundaries

Inspected package metadata/lockfile importer, build and skill-link scripts, CI/release workflows, host entrypoint, client registration/review controls, local supervisor/config/router, and selected OAuth credential/callback/transport paths. No candidate code, install scripts or builds were executed.

- No package install lifecycle hook is declared; build copies bundled skills and compiles source. CI checks out the declared pinned skills revision; dependency installation uses a frozen lockfile. This does not audit every transitive dependency or the packaged npm bytes.
- Local mode can execute `npm exec --yes --package busabase@latest -- busabase server ...` on demand and inherits the host environment. This is an unpinned runtime/supply-chain trust boundary, not a sandboxed operation. External mode avoids managed startup; custom command/args are administrator configuration.
- Remote mode requires HTTPS and uses OAuth grants in DSH's credential store, resource-scoped keys, PKCE and callback-state checking in the inspected paths.
- Local and remote MCP transports send a fixed `changeRequest` permission header. Human Inspector review uses a separate local HTTP route with same-origin checks and default confirmation prompts; the prompts are configurable. This is not a universal agent execution guard.
- No claim of full malware review, complete security clearance, runtime testing, or maintainer endorsement. Maintainer acceptance of these boundaries remains necessary.

## Checks

- No pre-existing Busabase listing in the checkout; GitHub issue/PR search returned zero on 2026-09-12.
- README-only additions, linked source repository accessible, whitespace/diff checks.
